### PR TITLE
Chapter 16

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.bignerdranch.android.criminalintent">
+    
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+                     android:maxSdkVersion="18"/>
+
+    <uses-feature android:name="android.hardware.camera"
+                  android:required="false"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
+++ b/app/src/main/java/com/bignerdranch/android/criminalintent/Crime.java
@@ -68,4 +68,8 @@ public class Crime {
     public void setSuspectNumber(String number) {
         mSuspectNumber = number;
     }
+
+    public String getPhotoFilename() {
+        return "IMG_" + getId().toString() + ".jpg";
+    }
 }

--- a/app/src/main/java/com/bignerdranch/android/criminalintent/CrimeLab.java
+++ b/app/src/main/java/com/bignerdranch/android/criminalintent/CrimeLab.java
@@ -4,11 +4,13 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Environment;
 
 import com.bignerdranch.android.criminalintent.database.CrimeBaseHelper;
 import com.bignerdranch.android.criminalintent.database.CrimeCursorWrapper;
 import com.bignerdranch.android.criminalintent.database.CrimeDbSchema.CrimeTable;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -70,6 +72,17 @@ public class CrimeLab {
         } finally {
             cursor.close();
         }
+    }
+
+    public File getPhotoFile(Crime crime) {
+        File externalFilesDir = mContext
+                .getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+
+        if (externalFilesDir == null) {
+            return null;
+        }
+
+        return new File(externalFilesDir, crime.getPhotoFilename());
     }
 
     public void updateCrime(Crime crime) {

--- a/app/src/main/java/com/bignerdranch/android/criminalintent/ZoomedPhotoFragment.java
+++ b/app/src/main/java/com/bignerdranch/android/criminalintent/ZoomedPhotoFragment.java
@@ -1,0 +1,43 @@
+package com.bignerdranch.android.criminalintent;
+
+import android.app.Dialog;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+
+/**
+ * Created by bretfears on 10/11/16.
+ */
+
+public class ZoomedPhotoFragment extends DialogFragment {
+
+    private static Bitmap mBitmap;
+
+    public static ZoomedPhotoFragment newInstance(Bitmap file) {
+        Bundle args = new Bundle();
+        mBitmap = file;
+
+        ZoomedPhotoFragment fragment = new ZoomedPhotoFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View view = LayoutInflater.from(getActivity())
+                .inflate(R.layout.dialog_zoomed_photo, null);
+
+        ImageView image = (ImageView) view.findViewById(R.id.image_area);
+        image.setImageBitmap(mBitmap);
+
+        return new AlertDialog.Builder(getActivity())
+                .setView(view)
+                .create();
+    }
+}

--- a/app/src/main/java/com/bignerdranch/android/criminalintent/utils/PictureUtils.java
+++ b/app/src/main/java/com/bignerdranch/android/criminalintent/utils/PictureUtils.java
@@ -1,0 +1,48 @@
+package com.bignerdranch.android.criminalintent.utils;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Point;
+
+/**
+ * Created by bretfears on 10/11/16.
+ */
+
+public class PictureUtils {
+
+    public static Bitmap getScaledBitmap(String path, Activity activity) {
+        Point size = new Point();
+        activity.getWindowManager().getDefaultDisplay()
+                .getSize(size);
+
+        return getScaledBitmap(path, size.x, size.y);
+    }
+
+    public static Bitmap getScaledBitmap(String path, int destWidth, int destHeight) {
+        // Read in the dimensions of the image on disk
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(path, options);
+
+        float srcWidth = options.outWidth;
+        float srcHeight = options.outHeight;
+
+        // Figure out how much to scale down by
+        int inSampleSize = 1;
+        if (srcHeight > destHeight || srcWidth > destWidth) {
+            if (srcWidth > srcHeight) {
+                inSampleSize = Math.round(srcHeight / destHeight);
+            } else {
+                inSampleSize = Math.round(srcWidth / destWidth);
+            }
+        }
+
+        options = new BitmapFactory.Options();
+        options.inSampleSize = inSampleSize;
+
+        // Read in and create final bitmap
+        return BitmapFactory.decodeFile(path, options);
+    }
+
+}

--- a/app/src/main/res/layout-land/fragment_crime.xml
+++ b/app/src/main/res/layout-land/fragment_crime.xml
@@ -3,19 +3,8 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/crime_title_label"
-        style="?android:listSeparatorTextViewStyle"/>
 
-    <EditText
-        android:id="@+id/crime_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:hint="@string/crime_title_hint"/>
+    <include layout="@layout/view_camera_and_title" />
 
     <TextView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_zoomed_photo.xml
+++ b/app/src/main/res/layout/dialog_zoomed_photo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/image_area"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:scaleType="centerInside">
+
+</ImageView>

--- a/app/src/main/res/layout/fragment_crime.xml
+++ b/app/src/main/res/layout/fragment_crime.xml
@@ -3,19 +3,8 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/crime_title_label"
-        style="?android:listSeparatorTextViewStyle"/>
 
-    <EditText
-        android:id="@+id/crime_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:hint="@string/crime_title_hint"/>
+    <include layout="@layout/view_camera_and_title" />
 
     <TextView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_camera_and_title.xml
+++ b/app/src/main/res/layout/view_camera_and_title.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="horizontal"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginLeft="16dp"
+              android:layout_marginTop="16dp">
+    
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginRight="4dp">
+
+        <ImageView
+            android:id="@+id/crime_photo"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:scaleType="centerInside"
+            android:background="@android:color/darker_gray"
+            android:cropToPadding="true"/>
+
+        <ImageButton
+            android:id="@+id/crime_camera"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_menu_camera"/>
+
+    </LinearLayout>
+    
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_weight="1">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/crime_title_label"
+            style="?android:listSeparatorTextViewStyle"/>
+        
+        <EditText
+            android:id="@+id/crime_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="16dp"
+            android:hint="@string/crime_title_hint"/>
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Adding crime photo support
- Uses implicit intent to use the select photo app to take a photo
  - Store the photo in the external store
  - Display a thumbnail view of the photo on the crime fragment within an ImageView
- Added a camera button to send the camera intent
- Adding a ZoomedPhotoFragmentDialog to display the larger bitmap
